### PR TITLE
test: ensure only 1 command/query handler registered locally

### DIFF
--- a/src/SaanSoft.Cqrs/Bus/BaseBusOptions.cs
+++ b/src/SaanSoft.Cqrs/Bus/BaseBusOptions.cs
@@ -1,0 +1,16 @@
+using Microsoft.Extensions.Logging;
+
+namespace SaanSoft.Cqrs.Bus;
+
+/// <summary>
+/// Common options for command/event/query buses
+/// Shouldn't be used directly
+/// </summary>
+public abstract class BaseBusOptions
+{
+    /// <summary>
+    /// The log level for log non-critical messages
+    /// </summary>
+    /// <value>@default Debug</value>
+    public LogLevel LogLevel { get; set; } = LogLevel.Debug;
+}

--- a/src/SaanSoft.Cqrs/Bus/CommandBusOptions.cs
+++ b/src/SaanSoft.Cqrs/Bus/CommandBusOptions.cs
@@ -1,0 +1,5 @@
+namespace SaanSoft.Cqrs.Bus;
+
+public class CommandBusOptions : BaseBusOptions
+{
+}

--- a/src/SaanSoft.Cqrs/Bus/EventBusOptions.cs
+++ b/src/SaanSoft.Cqrs/Bus/EventBusOptions.cs
@@ -1,0 +1,5 @@
+namespace SaanSoft.Cqrs.Bus;
+
+public class EventBusOptions : BaseBusOptions
+{
+}

--- a/src/SaanSoft.Cqrs/Bus/ICommandBus.cs
+++ b/src/SaanSoft.Cqrs/Bus/ICommandBus.cs
@@ -5,9 +5,15 @@ namespace SaanSoft.Cqrs.Bus;
 public interface ICommandBus<TMessageId> where TMessageId : struct
 {
     /// <summary>
-    /// Execute a command and wait for a CommandResult
+    /// Execute a command and wait for a CommandResult.
     /// The CommandResult indicates if it errored or not and an error message.
     /// </summary>
+    /// <remarks>
+    /// Use ExecuteAsync if you need to wait for the command to finish processing before continuing.
+    ///
+    /// Its recommended that its only used for commands that are handled within the same application
+    /// and doesn't depend on external infrastructure (e.g. using LocalCommandBus).
+    /// </remarks>
     /// <param name="command"></param>
     /// <param name="cancellationToken"></param>
     /// <typeparam name="TCommand"></typeparam>
@@ -15,9 +21,15 @@ public interface ICommandBus<TMessageId> where TMessageId : struct
     Task<CommandResult> ExecuteAsync<TCommand>(TCommand command, CancellationToken cancellationToken = default) where TCommand : ICommand<TMessageId>;
 
     /// <summary>
-    /// Put the command onto the queue (i.e. fire and forget)
-    /// It will not return any indication if the command was successfully executed or not
+    /// Put the command onto the queue (i.e. fire and forget).
+    /// It will not return any indication if the command was successfully executed or not.
     /// </summary>
+    /// <remarks>
+    /// Use QueueAsync if the command can be handled out of scope.
+    ///
+    /// Its recommended that its used for commands that are handled via external infrastructure
+    /// (e.g. Aws SQS, Azure Service Bus, RabbitMQ).
+    /// </remarks>
     /// <param name="command"></param>
     /// <param name="cancellationToken"></param>
     /// <typeparam name="TCommand"></typeparam>

--- a/src/SaanSoft.Cqrs/Bus/LocalCommandBus.cs
+++ b/src/SaanSoft.Cqrs/Bus/LocalCommandBus.cs
@@ -1,32 +1,51 @@
 using Microsoft.Extensions.DependencyInjection;
-
+using Microsoft.Extensions.Logging;
 using SaanSoft.Cqrs.Handler;
 using SaanSoft.Cqrs.Messages;
 
 namespace SaanSoft.Cqrs.Bus;
 
-public class LocalCommandBus(IServiceProvider serviceProvider)
-    : LocalCommandBus<Guid>(serviceProvider);
+public class LocalCommandBus(IServiceProvider serviceProvider, ILogger logger, CommandBusOptions? options = null)
+    : LocalCommandBus<Guid>(serviceProvider, logger, options);
 
-public abstract class LocalCommandBus<TMessageId>(IServiceProvider serviceProvider)
+public abstract class LocalCommandBus<TMessageId>
     : ICommandBus<TMessageId>
     where TMessageId : struct
 {
+    // ReSharper disable MemberCanBePrivate.Global
+    protected readonly CommandBusOptions Options;
+    protected readonly LogLevel LogLevel;
+    protected readonly IServiceProvider ServiceProvider;
+    protected readonly ILogger Logger;
+    // ReSharper restore MemberCanBePrivate.Global
+
+    protected LocalCommandBus(IServiceProvider serviceProvider, ILogger logger, CommandBusOptions? options = null)
+    {
+        Options = options ?? new CommandBusOptions();
+        LogLevel = Options.LogLevel;
+
+        ServiceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+        Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
     public async Task<CommandResult> ExecuteAsync<TCommand>(TCommand command, CancellationToken cancellationToken = default)
         where TCommand : ICommand<TMessageId>
     {
-        var handlers = serviceProvider.GetServices<ICommandHandler<TCommand>>()?.ToList() ?? [];
-        if (handlers.Count == 1)
+        var handlers = ServiceProvider.GetServices<ICommandHandler<TCommand>>()?.ToList() ?? [];
+        switch (handlers.Count)
         {
-            return await handlers.First().HandleAsync(command, cancellationToken);
+            case 1:
+                var handler = handlers.Single();
+                Logger.Log(LogLevel, "Running command handler '{HandlerType}' for '{MessageType}'", handler.GetType().FullName, typeof(TCommand).FullName);
+                return await handler.HandleAsync(command, cancellationToken);
+            case 0:
+                throw new InvalidOperationException($"No service for type '{typeof(ICommandHandler<TCommand>)}' has been registered.");
+            default:
+                {
+                    var typeNames = handlers.Select(x => x.GetType().FullName).ToList();
+                    throw new InvalidOperationException($"Only one service for type '{typeof(ICommandHandler<TCommand>)}' can be registered. Currently have {typeNames.Count} registered: {string.Join("; ", typeNames)}");
+                }
         }
-        if (handlers.Count == 0)
-        {
-            throw new InvalidOperationException($"No service for type '{typeof(ICommandHandler<TCommand>)}' has been registered");
-        }
-
-        var typeNames = handlers.Select(x => x.GetType().FullName).ToList();
-        throw new InvalidOperationException($"Only one service for type '{typeof(ICommandHandler<TCommand>)}' can be registered. Currently have {typeNames.Count} registered: {string.Join("; ", typeNames)}");
     }
 
     public async Task QueueAsync<TCommand>(TCommand command, CancellationToken cancellationToken = default)

--- a/src/SaanSoft.Cqrs/Bus/LocalCommandBus.cs
+++ b/src/SaanSoft.Cqrs/Bus/LocalCommandBus.cs
@@ -15,9 +15,18 @@ public abstract class LocalCommandBus<TMessageId>(IServiceProvider serviceProvid
     public async Task<CommandResult> ExecuteAsync<TCommand>(TCommand command, CancellationToken cancellationToken = default)
         where TCommand : ICommand<TMessageId>
     {
-        return await serviceProvider
-            .GetRequiredService<ICommandHandler<TCommand>>()
-            .HandleAsync(command, cancellationToken);
+        var handlers = serviceProvider.GetServices<ICommandHandler<TCommand>>()?.ToList() ?? [];
+        if (handlers.Count == 1)
+        {
+            return await handlers.First().HandleAsync(command, cancellationToken);
+        }
+        if (handlers.Count == 0)
+        {
+            throw new InvalidOperationException($"No service for type '{typeof(ICommandHandler<TCommand>)}' has been registered");
+        }
+
+        var typeNames = handlers.Select(x => x.GetType().FullName).ToList();
+        throw new InvalidOperationException($"Only one service for type '{typeof(ICommandHandler<TCommand>)}' can be registered. Currently have {typeNames.Count} registered: {string.Join("; ", typeNames)}");
     }
 
     public async Task QueueAsync<TCommand>(TCommand command, CancellationToken cancellationToken = default)

--- a/src/SaanSoft.Cqrs/Bus/LocalEventBus.cs
+++ b/src/SaanSoft.Cqrs/Bus/LocalEventBus.cs
@@ -1,17 +1,33 @@
 using Microsoft.Extensions.DependencyInjection;
-
+using Microsoft.Extensions.Logging;
 using SaanSoft.Cqrs.Handler;
 using SaanSoft.Cqrs.Messages;
 
 namespace SaanSoft.Cqrs.Bus;
 
-public class LocalEventBus(IServiceProvider serviceProvider)
-    : LocalEventBus<Guid>(serviceProvider);
+public class LocalEventBus(IServiceProvider serviceProvider, ILogger logger, EventBusOptions? options = null)
+    : LocalEventBus<Guid>(serviceProvider, logger, options);
 
-public abstract class LocalEventBus<TMessageId>(IServiceProvider serviceProvider)
+public abstract class LocalEventBus<TMessageId>
     : IEventBus<TMessageId>
     where TMessageId : struct
 {
+    // ReSharper disable MemberCanBePrivate.Global
+    protected readonly EventBusOptions Options;
+    protected readonly LogLevel LogLevel;
+    protected readonly IServiceProvider ServiceProvider;
+    protected readonly ILogger Logger;
+    // ReSharper restore MemberCanBePrivate.Global
+
+    protected LocalEventBus(IServiceProvider serviceProvider, ILogger logger, EventBusOptions? options = null)
+    {
+        Options = options ?? new EventBusOptions();
+        LogLevel = Options.LogLevel;
+
+        ServiceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+        Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
     public async Task QueueAsync<TEvent>(TEvent evt, CancellationToken cancellationToken = default)
         where TEvent : IEvent<TMessageId>
         => await QueueManyAsync([evt], cancellationToken);
@@ -19,12 +35,13 @@ public abstract class LocalEventBus<TMessageId>(IServiceProvider serviceProvider
     public async Task QueueManyAsync<TEvent>(IEnumerable<TEvent> events, CancellationToken cancellationToken = default)
         where TEvent : IEvent<TMessageId>
     {
-        var services = serviceProvider.GetServices<IEventHandler<TEvent>>()?.ToList() ?? [];
+        var handlers = ServiceProvider.GetServices<IEventHandler<TEvent>>()?.ToList() ?? [];
         foreach (var evt in events)
         {
-            foreach (var service in services)
+            foreach (var handler in handlers)
             {
-                await service.HandleAsync(evt, cancellationToken);
+                Logger.Log(LogLevel, "Running event handler '{HandlerType}' for '{MessageType}'", handler.GetType().FullName, typeof(TEvent).FullName);
+                await handler.HandleAsync(evt, cancellationToken);
             }
         }
     }

--- a/src/SaanSoft.Cqrs/Bus/LocalQueryBus.cs
+++ b/src/SaanSoft.Cqrs/Bus/LocalQueryBus.cs
@@ -1,23 +1,51 @@
 using Microsoft.Extensions.DependencyInjection;
-
+using Microsoft.Extensions.Logging;
 using SaanSoft.Cqrs.Handler;
 using SaanSoft.Cqrs.Messages;
 
 namespace SaanSoft.Cqrs.Bus;
 
-public class LocalQueryBus(IServiceProvider serviceProvider)
-    : LocalQueryBus<Guid>(serviceProvider);
+public class LocalQueryBus(IServiceProvider serviceProvider, ILogger logger, QueryBusOptions? options = null)
+    : LocalQueryBus<Guid>(serviceProvider, logger, options);
 
-public abstract class LocalQueryBus<TMessageId>(IServiceProvider serviceProvider)
+public abstract class LocalQueryBus<TMessageId>
     : IQueryBus<TMessageId>
     where TMessageId : struct
 {
+    // ReSharper disable MemberCanBePrivate.Global
+    protected readonly QueryBusOptions Options;
+    protected readonly LogLevel LogLevel;
+    protected readonly IServiceProvider ServiceProvider;
+    protected readonly ILogger Logger;
+    // ReSharper restore MemberCanBePrivate.Global
+
+    protected LocalQueryBus(IServiceProvider serviceProvider, ILogger logger, QueryBusOptions? options = null)
+    {
+        Options = options ?? new QueryBusOptions();
+        LogLevel = Options.LogLevel;
+
+        ServiceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+        Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
     public async Task<TResult> QueryAsync<TQuery, TResult>(TQuery query, CancellationToken cancellationToken = default)
         where TQuery : IQuery<TMessageId, TQuery, TResult>
         where TResult : IQueryResult
     {
-        return await serviceProvider
-            .GetRequiredService<IQueryHandler<TQuery, TResult>>()
-            .HandleAsync(query, cancellationToken);
+        var handlers = ServiceProvider.GetServices<IQueryHandler<TQuery, TResult>>()?.ToList() ?? [];
+        switch (handlers.Count)
+        {
+            case 1:
+                var handler = handlers.Single();
+                Logger.Log(LogLevel, "Running query handler '{HandlerType}' for '{MessageType}'", handler.GetType().FullName, typeof(TQuery).FullName);
+                return await handlers.First().HandleAsync(query, cancellationToken);
+            case 0:
+                throw new InvalidOperationException($"No service for type '{typeof(IQueryHandler<TQuery, TResult>)}' has been registered.");
+            default:
+                {
+                    var typeNames = handlers.Select(x => x.GetType().FullName).ToList();
+                    throw new InvalidOperationException($"Only one service for type '{typeof(IQueryHandler<TQuery, TResult>)}' can be registered. Currently have {typeNames.Count} registered: {string.Join("; ", typeNames)}");
+                }
+        }
     }
 }

--- a/src/SaanSoft.Cqrs/Bus/QueryBusOptions.cs
+++ b/src/SaanSoft.Cqrs/Bus/QueryBusOptions.cs
@@ -1,0 +1,5 @@
+namespace SaanSoft.Cqrs.Bus;
+
+public class QueryBusOptions : BaseBusOptions
+{
+}

--- a/src/SaanSoft.Cqrs/Handler/ICommandHandler.cs
+++ b/src/SaanSoft.Cqrs/Handler/ICommandHandler.cs
@@ -7,7 +7,7 @@ public interface ICommandHandler<in TCommand> where TCommand : ICommand
     /// <summary>
     /// Process the command including validation and other business logic to ensure its valid to continue.
     /// Command handling should not alter any state in the DB.
-    /// Will usually raise one or more associated events.
+    /// The handler will often raise one or more associated events.
     /// </summary>
     /// <param name="command"></param>
     /// <param name="cancellationToken"></param>

--- a/src/SaanSoft.Cqrs/SaanSoft.Cqrs.csproj
+++ b/src/SaanSoft.Cqrs/SaanSoft.Cqrs.csproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1"/>
   </ItemGroup>
 
 </Project>

--- a/test/SaanSoft.Tests.Cqrs/Bus/LocalCommandBusTests.cs
+++ b/test/SaanSoft.Tests.Cqrs/Bus/LocalCommandBusTests.cs
@@ -11,6 +11,7 @@ namespace SaanSoft.Tests.Cqrs.Bus;
 public class LocalCommandBusTests
 {
     private readonly ILogger _logger = A.Fake<ILogger>();
+    private readonly CommandBusOptions _options = new();
 
     [Fact]
     public void Cant_create_with_null_serviceProvider()
@@ -44,7 +45,7 @@ public class LocalCommandBusTests
         var serviceCollection = new ServiceCollection();
         serviceCollection.AddScoped<ICommandHandler<GuidCommand>>(_ => handler);
 
-        var sut = new LocalCommandBus(serviceCollection.BuildServiceProvider(), _logger);
+        var sut = new LocalCommandBus(serviceCollection.BuildServiceProvider(), _logger, _options);
         var result = await sut.ExecuteAsync(new GuidCommand());
         result.IsSuccess.Should().BeTrue();
 

--- a/test/SaanSoft.Tests.Cqrs/Bus/LocalCommandBusTests.cs
+++ b/test/SaanSoft.Tests.Cqrs/Bus/LocalCommandBusTests.cs
@@ -27,7 +27,7 @@ public class LocalCommandBusTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_no_handler_in_serviceProvider_should_throw_exception()
+    public async Task ExecuteAsync_no_handler_in_serviceProvider_should_throw_error()
     {
         var serviceCollection = new ServiceCollection();
 
@@ -35,7 +35,37 @@ public class LocalCommandBusTests
 
         await sut.Invoking(y => y.ExecuteAsync(new GuidCommand()))
             .Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage($"No service for type '{typeof(ICommandHandler<GuidCommand>)}' has been registered.");
+            .Where(x =>
+                x.Message.StartsWith("No service for type") &&
+                x.Message.EndsWith("has been registered")
+            );
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_multiple_handlers_exists_in_serviceProvider_should_throw_error()
+    {
+        var handler1 = A.Fake<ICommandHandler<GuidCommand>>();
+        A.CallTo(() => handler1.HandleAsync(A<GuidCommand>.Ignored, A<CancellationToken>.Ignored))
+            .Returns(new CommandResult());
+
+        var handler2 = A.Fake<ICommandHandler<GuidCommand>>();
+        A.CallTo(() => handler2.HandleAsync(A<GuidCommand>.Ignored, A<CancellationToken>.Ignored))
+            .Returns(new CommandResult());
+
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddScoped<ICommandHandler<GuidCommand>>(_ => handler1);
+        serviceCollection.AddScoped<ICommandHandler<GuidCommand>>(_ => handler2);
+
+        var sut = new LocalCommandBus(serviceCollection.BuildServiceProvider());
+        await sut.Invoking(y => y.ExecuteAsync(new GuidCommand()))
+            .Should().ThrowAsync<InvalidOperationException>()
+            .Where(x =>
+                x.Message.StartsWith("Only one service for type") &&
+                x.Message.Contains("can be registered")
+            );
+
+        A.CallTo(() => handler1.HandleAsync(A<GuidCommand>.Ignored, A<CancellationToken>.Ignored)).MustNotHaveHappened();
+        A.CallTo(() => handler2.HandleAsync(A<GuidCommand>.Ignored, A<CancellationToken>.Ignored)).MustNotHaveHappened();
     }
 
     [Fact]
@@ -53,14 +83,44 @@ public class LocalCommandBusTests
     }
 
     [Fact]
-    public async Task QueueAsync_no_handler_in_serviceProvider_should_throw_exception()
+    public async Task QueueAsync_no_handler_in_serviceProvider_should_throw_error()
     {
         var serviceCollection = new ServiceCollection();
 
         var sut = new LocalCommandBus(serviceCollection.BuildServiceProvider());
 
+        await sut.Invoking(y => y.ExecuteAsync(new GuidCommand()))
+            .Should().ThrowAsync<InvalidOperationException>()
+            .Where(x =>
+                x.Message.StartsWith("No service for type") &&
+                x.Message.EndsWith("has been registered")
+            );
+    }
+
+    [Fact]
+    public async Task QueueAsync_multiple_handlers_in_serviceProvider_should_throw_error()
+    {
+        var handler1 = A.Fake<ICommandHandler<GuidCommand>>();
+        A.CallTo(() => handler1.HandleAsync(A<GuidCommand>.Ignored, A<CancellationToken>.Ignored))
+            .Returns(new CommandResult());
+
+        var handler2 = A.Fake<ICommandHandler<GuidCommand>>();
+        A.CallTo(() => handler2.HandleAsync(A<GuidCommand>.Ignored, A<CancellationToken>.Ignored))
+            .Returns(new CommandResult());
+
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddScoped<ICommandHandler<GuidCommand>>(_ => handler1);
+        serviceCollection.AddScoped<ICommandHandler<GuidCommand>>(_ => handler2);
+
+        var sut = new LocalCommandBus(serviceCollection.BuildServiceProvider());
         await sut.Invoking(y => y.QueueAsync(new GuidCommand()))
             .Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage($"No service for type '{typeof(ICommandHandler<GuidCommand>)}' has been registered.");
+            .Where(x =>
+                x.Message.StartsWith("Only one service for type") &&
+                x.Message.Contains("can be registered")
+            );
+
+        A.CallTo(() => handler1.HandleAsync(A<GuidCommand>.Ignored, A<CancellationToken>.Ignored)).MustNotHaveHappened();
+        A.CallTo(() => handler2.HandleAsync(A<GuidCommand>.Ignored, A<CancellationToken>.Ignored)).MustNotHaveHappened();
     }
 }

--- a/test/SaanSoft.Tests.Cqrs/Bus/LocalCommandBusTests.cs
+++ b/test/SaanSoft.Tests.Cqrs/Bus/LocalCommandBusTests.cs
@@ -13,6 +13,28 @@ public class LocalCommandBusTests
     private readonly ILogger _logger = A.Fake<ILogger>();
 
     [Fact]
+    public void Cant_create_with_null_serviceProvider()
+    {
+        Action act = () => new LocalCommandBus(null, _logger);
+
+        act.Should()
+            .Throw<ArgumentNullException>()
+            .Where(x => x.ParamName == "serviceProvider");
+    }
+
+    [Fact]
+    public void Cant_create_with_null_logger()
+    {
+        var serviceCollection = new ServiceCollection();
+
+        Action act = () => new LocalCommandBus(serviceCollection.BuildServiceProvider(), null);
+
+        act.Should()
+            .Throw<ArgumentNullException>()
+            .Where(x => x.ParamName == "logger");
+    }
+
+    [Fact]
     public async Task ExecuteAsync_handler_exists_in_serviceProvider()
     {
         var handler = A.Fake<ICommandHandler<GuidCommand>>();

--- a/test/SaanSoft.Tests.Cqrs/Bus/LocalCommandBusTests.cs
+++ b/test/SaanSoft.Tests.Cqrs/Bus/LocalCommandBusTests.cs
@@ -1,5 +1,6 @@
 using FakeItEasy;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using SaanSoft.Cqrs.Bus;
 using SaanSoft.Cqrs.Handler;
 using SaanSoft.Cqrs.Messages;
@@ -9,6 +10,8 @@ namespace SaanSoft.Tests.Cqrs.Bus;
 
 public class LocalCommandBusTests
 {
+    private readonly ILogger _logger = A.Fake<ILogger>();
+
     [Fact]
     public async Task ExecuteAsync_handler_exists_in_serviceProvider()
     {
@@ -19,7 +22,7 @@ public class LocalCommandBusTests
         var serviceCollection = new ServiceCollection();
         serviceCollection.AddScoped<ICommandHandler<GuidCommand>>(_ => handler);
 
-        var sut = new LocalCommandBus(serviceCollection.BuildServiceProvider());
+        var sut = new LocalCommandBus(serviceCollection.BuildServiceProvider(), _logger);
         var result = await sut.ExecuteAsync(new GuidCommand());
         result.IsSuccess.Should().BeTrue();
 
@@ -31,13 +34,13 @@ public class LocalCommandBusTests
     {
         var serviceCollection = new ServiceCollection();
 
-        var sut = new LocalCommandBus(serviceCollection.BuildServiceProvider());
+        var sut = new LocalCommandBus(serviceCollection.BuildServiceProvider(), _logger);
 
         await sut.Invoking(y => y.ExecuteAsync(new GuidCommand()))
             .Should().ThrowAsync<InvalidOperationException>()
             .Where(x =>
                 x.Message.StartsWith("No service for type") &&
-                x.Message.EndsWith("has been registered")
+                x.Message.EndsWith("has been registered.")
             );
     }
 
@@ -45,18 +48,13 @@ public class LocalCommandBusTests
     public async Task ExecuteAsync_multiple_handlers_exists_in_serviceProvider_should_throw_error()
     {
         var handler1 = A.Fake<ICommandHandler<GuidCommand>>();
-        A.CallTo(() => handler1.HandleAsync(A<GuidCommand>.Ignored, A<CancellationToken>.Ignored))
-            .Returns(new CommandResult());
-
         var handler2 = A.Fake<ICommandHandler<GuidCommand>>();
-        A.CallTo(() => handler2.HandleAsync(A<GuidCommand>.Ignored, A<CancellationToken>.Ignored))
-            .Returns(new CommandResult());
 
         var serviceCollection = new ServiceCollection();
         serviceCollection.AddScoped<ICommandHandler<GuidCommand>>(_ => handler1);
         serviceCollection.AddScoped<ICommandHandler<GuidCommand>>(_ => handler2);
 
-        var sut = new LocalCommandBus(serviceCollection.BuildServiceProvider());
+        var sut = new LocalCommandBus(serviceCollection.BuildServiceProvider(), _logger);
         await sut.Invoking(y => y.ExecuteAsync(new GuidCommand()))
             .Should().ThrowAsync<InvalidOperationException>()
             .Where(x =>
@@ -76,7 +74,7 @@ public class LocalCommandBusTests
         var serviceCollection = new ServiceCollection();
         serviceCollection.AddScoped<ICommandHandler<GuidCommand>>(_ => handler);
 
-        var sut = new LocalCommandBus(serviceCollection.BuildServiceProvider());
+        var sut = new LocalCommandBus(serviceCollection.BuildServiceProvider(), _logger);
         await sut.QueueAsync(new GuidCommand());
 
         A.CallTo(() => handler.HandleAsync(A<GuidCommand>.That.IsNotNull(), A<CancellationToken>._)).MustHaveHappened();
@@ -87,13 +85,13 @@ public class LocalCommandBusTests
     {
         var serviceCollection = new ServiceCollection();
 
-        var sut = new LocalCommandBus(serviceCollection.BuildServiceProvider());
+        var sut = new LocalCommandBus(serviceCollection.BuildServiceProvider(), _logger);
 
         await sut.Invoking(y => y.ExecuteAsync(new GuidCommand()))
             .Should().ThrowAsync<InvalidOperationException>()
             .Where(x =>
                 x.Message.StartsWith("No service for type") &&
-                x.Message.EndsWith("has been registered")
+                x.Message.EndsWith("has been registered.")
             );
     }
 
@@ -101,18 +99,13 @@ public class LocalCommandBusTests
     public async Task QueueAsync_multiple_handlers_in_serviceProvider_should_throw_error()
     {
         var handler1 = A.Fake<ICommandHandler<GuidCommand>>();
-        A.CallTo(() => handler1.HandleAsync(A<GuidCommand>.Ignored, A<CancellationToken>.Ignored))
-            .Returns(new CommandResult());
-
         var handler2 = A.Fake<ICommandHandler<GuidCommand>>();
-        A.CallTo(() => handler2.HandleAsync(A<GuidCommand>.Ignored, A<CancellationToken>.Ignored))
-            .Returns(new CommandResult());
 
         var serviceCollection = new ServiceCollection();
         serviceCollection.AddScoped<ICommandHandler<GuidCommand>>(_ => handler1);
         serviceCollection.AddScoped<ICommandHandler<GuidCommand>>(_ => handler2);
 
-        var sut = new LocalCommandBus(serviceCollection.BuildServiceProvider());
+        var sut = new LocalCommandBus(serviceCollection.BuildServiceProvider(), _logger);
         await sut.Invoking(y => y.QueueAsync(new GuidCommand()))
             .Should().ThrowAsync<InvalidOperationException>()
             .Where(x =>

--- a/test/SaanSoft.Tests.Cqrs/Bus/LocalEventBusTests.cs
+++ b/test/SaanSoft.Tests.Cqrs/Bus/LocalEventBusTests.cs
@@ -12,6 +12,28 @@ public class LocalEventBusTests
     private readonly ILogger _logger = A.Fake<ILogger>();
 
     [Fact]
+    public void Cant_create_with_null_serviceProvider()
+    {
+        Action act = () => new LocalEventBus(null, _logger);
+
+        act.Should()
+            .Throw<ArgumentNullException>()
+            .Where(x => x.ParamName == "serviceProvider");
+    }
+
+    [Fact]
+    public void Cant_create_with_null_logger()
+    {
+        var serviceCollection = new ServiceCollection();
+
+        Action act = () => new LocalEventBus(serviceCollection.BuildServiceProvider(), null);
+
+        act.Should()
+            .Throw<ArgumentNullException>()
+            .Where(x => x.ParamName == "logger");
+    }
+
+    [Fact]
     public async Task ExecuteAsync_single_handler_exists_in_serviceProvider()
     {
         var eventHandler = A.Fake<IEventHandler<GuidEvent>>();

--- a/test/SaanSoft.Tests.Cqrs/Bus/LocalEventBusTests.cs
+++ b/test/SaanSoft.Tests.Cqrs/Bus/LocalEventBusTests.cs
@@ -1,5 +1,6 @@
 using FakeItEasy;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using SaanSoft.Cqrs.Bus;
 using SaanSoft.Cqrs.Handler;
 using SaanSoft.Tests.Cqrs.TestHelpers;
@@ -8,6 +9,8 @@ namespace SaanSoft.Tests.Cqrs.Bus;
 
 public class LocalEventBusTests
 {
+    private readonly ILogger _logger = A.Fake<ILogger>();
+
     [Fact]
     public async Task ExecuteAsync_single_handler_exists_in_serviceProvider()
     {
@@ -16,12 +19,16 @@ public class LocalEventBusTests
         var serviceCollection = new ServiceCollection();
         serviceCollection.AddScoped<IEventHandler<GuidEvent>>(_ => eventHandler);
 
-        var sut = new LocalEventBus(serviceCollection.BuildServiceProvider());
+        var sut = new LocalEventBus(serviceCollection.BuildServiceProvider(), _logger);
         await sut.QueueAsync(new GuidEvent(Guid.NewGuid()));
 
         A.CallTo(() => eventHandler.HandleAsync(A<GuidEvent>.That.IsNotNull(), A<CancellationToken>._)).MustHaveHappened();
     }
 
+    /// <summary>
+    /// Unlike commands and queries, having multiple event handlers is fine,
+    /// and both event handlers should be run
+    /// </summary>
     [Fact]
     public async Task ExecuteAsync_multiple_handlers_exists_in_serviceProvider()
     {
@@ -32,19 +39,22 @@ public class LocalEventBusTests
         serviceCollection.AddScoped<IEventHandler<GuidEvent>>(_ => eventHandler);
         serviceCollection.AddScoped<IEventHandler<GuidEvent>>(_ => anotherEventHandler);
 
-        var sut = new LocalEventBus(serviceCollection.BuildServiceProvider());
+        var sut = new LocalEventBus(serviceCollection.BuildServiceProvider(), _logger);
         await sut.QueueAsync(new GuidEvent(Guid.NewGuid()));
 
         A.CallTo(() => eventHandler.HandleAsync(A<GuidEvent>.That.IsNotNull(), A<CancellationToken>._)).MustHaveHappened();
         A.CallTo(() => anotherEventHandler.HandleAsync(A<GuidEvent>.That.IsNotNull(), A<CancellationToken>._)).MustHaveHappened();
     }
 
+    /// <summary>
+    /// Unlike commands and queries, having no event handlers is fine, it just does nothing.
+    /// </summary>
     [Fact]
     public async Task ExecuteAsync_no_handler_in_serviceProvider_should_do_nothing()
     {
         var serviceCollection = new ServiceCollection();
 
-        var sut = new LocalEventBus(serviceCollection.BuildServiceProvider());
+        var sut = new LocalEventBus(serviceCollection.BuildServiceProvider(), _logger);
         await sut.QueueAsync(new GuidEvent(Guid.NewGuid()));
 
         Assert.True(true);

--- a/test/SaanSoft.Tests.Cqrs/Bus/LocalEventBusTests.cs
+++ b/test/SaanSoft.Tests.Cqrs/Bus/LocalEventBusTests.cs
@@ -10,6 +10,7 @@ namespace SaanSoft.Tests.Cqrs.Bus;
 public class LocalEventBusTests
 {
     private readonly ILogger _logger = A.Fake<ILogger>();
+    private readonly EventBusOptions _options = new();
 
     [Fact]
     public void Cant_create_with_null_serviceProvider()
@@ -41,7 +42,7 @@ public class LocalEventBusTests
         var serviceCollection = new ServiceCollection();
         serviceCollection.AddScoped<IEventHandler<GuidEvent>>(_ => eventHandler);
 
-        var sut = new LocalEventBus(serviceCollection.BuildServiceProvider(), _logger);
+        var sut = new LocalEventBus(serviceCollection.BuildServiceProvider(), _logger, _options);
         await sut.QueueAsync(new GuidEvent(Guid.NewGuid()));
 
         A.CallTo(() => eventHandler.HandleAsync(A<GuidEvent>.That.IsNotNull(), A<CancellationToken>._)).MustHaveHappened();

--- a/test/SaanSoft.Tests.Cqrs/Bus/LocalQueryBusTests.cs
+++ b/test/SaanSoft.Tests.Cqrs/Bus/LocalQueryBusTests.cs
@@ -12,6 +12,28 @@ public class LocalQueryBusTests
     private readonly ILogger _logger = A.Fake<ILogger>();
 
     [Fact]
+    public void Cant_create_with_null_serviceProvider()
+    {
+        Action act = () => new LocalQueryBus(null, _logger);
+
+        act.Should()
+            .Throw<ArgumentNullException>()
+            .Where(x => x.ParamName == "serviceProvider");
+    }
+
+    [Fact]
+    public void Cant_create_with_null_logger()
+    {
+        var serviceCollection = new ServiceCollection();
+
+        Action act = () => new LocalQueryBus(serviceCollection.BuildServiceProvider(), null);
+
+        act.Should()
+            .Throw<ArgumentNullException>()
+            .Where(x => x.ParamName == "logger");
+    }
+
+    [Fact]
     public async Task QueryAsync_handler_exists_in_serviceProvider()
     {
         var handler = A.Fake<IQueryHandler<GuidQuery, QueryResult>>();

--- a/test/SaanSoft.Tests.Cqrs/Bus/LocalQueryBusTests.cs
+++ b/test/SaanSoft.Tests.Cqrs/Bus/LocalQueryBusTests.cs
@@ -1,5 +1,6 @@
 using FakeItEasy;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using SaanSoft.Cqrs.Bus;
 using SaanSoft.Cqrs.Handler;
 using SaanSoft.Tests.Cqrs.TestHelpers;
@@ -8,6 +9,8 @@ namespace SaanSoft.Tests.Cqrs.Bus;
 
 public class LocalQueryBusTests
 {
+    private readonly ILogger _logger = A.Fake<ILogger>();
+
     [Fact]
     public async Task QueryAsync_handler_exists_in_serviceProvider()
     {
@@ -18,22 +21,47 @@ public class LocalQueryBusTests
         var serviceCollection = new ServiceCollection();
         serviceCollection.AddScoped<IQueryHandler<GuidQuery, QueryResult>>(_ => handler);
 
-        var sut = new LocalQueryBus(serviceCollection.BuildServiceProvider());
+        var sut = new LocalQueryBus(serviceCollection.BuildServiceProvider(), _logger);
         var result = await sut.QueryAsync<GuidQuery, QueryResult>(new GuidQuery());
         result.IsSuccess.Should().BeTrue();
 
-        A.CallTo(() => handler.HandleAsync(A<GuidQuery>.That.IsNotNull(), A<CancellationToken>._)).MustHaveHappened();
+        A.CallTo(() => handler.HandleAsync(A<GuidQuery>.Ignored, A<CancellationToken>.Ignored)).MustHaveHappened();
     }
 
     [Fact]
-    public async Task QueryAsync_no_handler_in_serviceProvider_should_throw_exception()
+    public async Task QueryAsync_no_handler_in_serviceProvider_should_throw_error()
     {
         var serviceCollection = new ServiceCollection();
 
-        var sut = new LocalQueryBus(serviceCollection.BuildServiceProvider());
+        var sut = new LocalQueryBus(serviceCollection.BuildServiceProvider(), _logger);
 
         await sut.Invoking(y => y.QueryAsync<GuidQuery, QueryResult>(new GuidQuery()))
             .Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage($"No service for type '{typeof(IQueryHandler<GuidQuery, QueryResult>)}' has been registered.");
+            .Where(x =>
+                x.Message.StartsWith("No service for type") &&
+                x.Message.EndsWith("has been registered.")
+            );
+    }
+
+    [Fact]
+    public async Task QueryAsync_multiple_handlers_exists_in_serviceProvider_should_throw_error()
+    {
+        var handler1 = A.Fake<IQueryHandler<GuidQuery, QueryResult>>();
+        var handler2 = A.Fake<IQueryHandler<GuidQuery, QueryResult>>();
+
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddScoped<IQueryHandler<GuidQuery, QueryResult>>(_ => handler1);
+        serviceCollection.AddScoped<IQueryHandler<GuidQuery, QueryResult>>(_ => handler2);
+
+        var sut = new LocalQueryBus(serviceCollection.BuildServiceProvider(), _logger);
+        await sut.Invoking(y => y.QueryAsync<GuidQuery, QueryResult>(new GuidQuery()))
+            .Should().ThrowAsync<InvalidOperationException>()
+            .Where(x =>
+                x.Message.StartsWith("Only one service for type") &&
+                x.Message.Contains("can be registered")
+            );
+
+        A.CallTo(() => handler1.HandleAsync(A<GuidQuery>.Ignored, A<CancellationToken>.Ignored)).MustNotHaveHappened();
+        A.CallTo(() => handler2.HandleAsync(A<GuidQuery>.Ignored, A<CancellationToken>.Ignored)).MustNotHaveHappened();
     }
 }

--- a/test/SaanSoft.Tests.Cqrs/Bus/LocalQueryBusTests.cs
+++ b/test/SaanSoft.Tests.Cqrs/Bus/LocalQueryBusTests.cs
@@ -10,6 +10,7 @@ namespace SaanSoft.Tests.Cqrs.Bus;
 public class LocalQueryBusTests
 {
     private readonly ILogger _logger = A.Fake<ILogger>();
+    private readonly QueryBusOptions _options = new();
 
     [Fact]
     public void Cant_create_with_null_serviceProvider()
@@ -43,7 +44,7 @@ public class LocalQueryBusTests
         var serviceCollection = new ServiceCollection();
         serviceCollection.AddScoped<IQueryHandler<GuidQuery, QueryResult>>(_ => handler);
 
-        var sut = new LocalQueryBus(serviceCollection.BuildServiceProvider(), _logger);
+        var sut = new LocalQueryBus(serviceCollection.BuildServiceProvider(), _logger, _options);
         var result = await sut.QueryAsync<GuidQuery, QueryResult>(new GuidQuery());
         result.IsSuccess.Should().BeTrue();
 

--- a/test/SaanSoft.Tests.Cqrs/SaanSoft.Tests.Cqrs.csproj
+++ b/test/SaanSoft.Tests.Cqrs/SaanSoft.Tests.Cqrs.csproj
@@ -22,6 +22,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+      
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0"/>
         <PackageReference Include="xunit" Version="2.7.0"/>
     </ItemGroup>

--- a/test/SaanSoft.Tests.Cqrs/TestHelpers/MyCommand.cs
+++ b/test/SaanSoft.Tests.Cqrs/TestHelpers/MyCommand.cs
@@ -1,0 +1,10 @@
+using SaanSoft.Cqrs.Messages;
+
+namespace SaanSoft.Tests.Cqrs.TestHelpers;
+
+public class MyCommand : BaseCommand
+{
+    public MyCommand() : base()
+    {
+    }
+}


### PR DESCRIPTION
### :spiral_notepad: Description

* Add tests to check that only one command/query handler is registered
* Add bus options so can log executions

### :white_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable -->

- [ ] Linked to any related issues in the PR description
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Breaking changes were made
