### PR TITLE
feature: record message publisher

### DIFF
--- a/examples/SaanSoft.Cqrs.Example.InMemory.Api/Controllers/WeatherForecastController.cs
+++ b/examples/SaanSoft.Cqrs.Example.InMemory.Api/Controllers/WeatherForecastController.cs
@@ -4,19 +4,21 @@ namespace SaanSoft.Cqrs.Example.InMemory.Api.Controllers;
 
 [ApiController]
 [Route("[controller]")]
-public class WeatherForecastController : ControllerBase
+public class WeatherForecastController(ILogger<WeatherForecastController> logger) : ControllerBase
 {
-    private static readonly string[] Summaries = new[]
-    {
-        "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
-    };
-
-    private readonly ILogger<WeatherForecastController> _logger;
-
-    public WeatherForecastController(ILogger<WeatherForecastController> logger)
-    {
-        _logger = logger;
-    }
+    private static readonly string[] Summaries =
+    [
+        "Freezing",
+        "Bracing",
+        "Chilly",
+        "Cool",
+        "Mild",
+        "Warm",
+        "Balmy",
+        "Hot",
+        "Sweltering",
+        "Scorching"
+    ];
 
     [HttpGet(Name = "GetWeatherForecast")]
     public IEnumerable<WeatherForecast> Get()

--- a/src/SaanSoft.Cqrs.Store.MongoDB/BaseMessageStore.cs
+++ b/src/SaanSoft.Cqrs.Store.MongoDB/BaseMessageStore.cs
@@ -1,5 +1,6 @@
 using MongoDB.Driver;
 using SaanSoft.Cqrs.Messages;
+using SaanSoft.Cqrs.Store.MongoDB.Models;
 using SaanSoft.Cqrs.Utilities;
 
 namespace SaanSoft.Cqrs.Store.MongoDB;
@@ -12,6 +13,7 @@ namespace SaanSoft.Cqrs.Store.MongoDB;
 /// <typeparam name="TMessageId"></typeparam>
 /// <typeparam name="TMessage"></typeparam>
 public abstract class BaseMessageStore<TMessageId, TMessage>(IMongoDatabase database) :
+    IMessagePublisherStore,
     IMessageStore<TMessageId, TMessage>
     where TMessageId : struct
     where TMessage : class, IMessage<TMessageId>
@@ -19,9 +21,16 @@ public abstract class BaseMessageStore<TMessageId, TMessage>(IMongoDatabase data
     // ReSharper disable once MemberCanBePrivate.Global
     protected readonly IMongoDatabase Database = database;
 
+    protected abstract TMessageId NewMessageId();
+
     public abstract string MessageCollectionName { get; }
+    public abstract string PublisherCollectionName { get; }
 
     public IMongoCollection<IMessage<TMessageId>> MessageCollection => Database.GetCollection<IMessage<TMessageId>>(MessageCollectionName);
+    public IMongoCollection<MessagePublisherRecord<TMessageId>> PublisherCollection => Database.GetCollection<MessagePublisherRecord<TMessageId>>(PublisherCollectionName);
+
+
+    #region IMessageStore<TMessageId, TMessage>
 
     public async Task InsertAsync(TMessage message, CancellationToken cancellationToken = default)
         => await InsertManyAsync([message], cancellationToken);
@@ -31,16 +40,52 @@ public abstract class BaseMessageStore<TMessageId, TMessage>(IMongoDatabase data
         var localMessages = message.Where(x => !x.IsReplay).ToList();
         if (localMessages.Count == 0) return;
 
+        localMessages = localMessages
+            .Select(msg =>
+            {
+                if (GenericUtils.IsNullOrDefault(msg.Id)) msg.Id = NewMessageId();
+                return msg;
+            })
+            .ToList();
+
         await MessageCollection.InsertManyAsync(localMessages, new InsertManyOptions(), cancellationToken);
     }
 
-    /// <summary>
-    /// Call this on your app startup to ensure that the necessary indexes are created
-    /// </summary>
-    public virtual async Task EnsureIndexes(CancellationToken cancellationToken = default)
-    {
-        var indexes = MessageCollection.Indexes;
+    #endregion
 
+    #region IMessagePublisherStore
+
+    public async Task UpsertPublisherAsync(string messageTypeName, string publisherTypeName, CancellationToken cancellationToken = default)
+    {
+        var record = await PublisherCollection
+                         .Find(x => x.MessageTypeName == messageTypeName && x.PublisherTypeName == publisherTypeName)
+                         .FirstOrDefaultAsync(cancellationToken: cancellationToken)
+                    ?? new MessagePublisherRecord<TMessageId>
+                    {
+                        Id = NewMessageId(),
+                        MessageTypeName = messageTypeName,
+                        PublisherTypeName = publisherTypeName,
+                        CreatedOn = DateTime.Now
+                    };
+        record.LastMessageOn = DateTime.Now;
+
+        await PublisherCollection.ReplaceOneAsync(
+            x => x.MessageTypeName == messageTypeName && x.PublisherTypeName == publisherTypeName,
+            record,
+            new ReplaceOptions { IsUpsert = true },
+            cancellationToken
+        );
+    }
+
+    #endregion
+
+    #region Create indexes
+
+    /// <summary>
+    /// Call in the app startup to ensure that the necessary indexes are created for the MessageCollection
+    /// </summary>
+    public virtual async Task EnsureMessageCollectionIndexes(CancellationToken cancellationToken = default)
+    {
         var keyIndex = Builders<IMessage<TMessageId>>.IndexKeys
             .Ascending(x => x.TypeFullName)
             .Ascending(x => x.TriggeredById)
@@ -50,15 +95,23 @@ public abstract class BaseMessageStore<TMessageId, TMessage>(IMongoDatabase data
         var indexModel =
             new CreateIndexModel<IMessage<TMessageId>>(keyIndex, new CreateIndexOptions { Unique = false, Background = false });
 
-        // await indexes.CreateOneAsync(
-        //     Builders<IMessage<TMessageId>>.IndexKeys.Ascending(_ => _.TypeFullName).Descending(_ => _.TriggeredById),
-        //     new CreateIndexOptions { Background = true },
-        //     cancellationToken);
-
-        await indexes.CreateOneAsync(
-            indexModel,
-                new CreateOneIndexOptions { },
-                cancellationToken
-            );
+        await MessageCollection.Indexes.CreateOneAsync(indexModel, new CreateOneIndexOptions(), cancellationToken);
     }
+
+    /// <summary>
+    /// Call in the app startup to ensure that the necessary indexes are created for the PublisherCollection
+    /// </summary>
+    public virtual async Task EnsurePublisherCollectionIndexes(CancellationToken cancellationToken = default)
+    {
+        var keyIndex = Builders<MessagePublisherRecord<TMessageId>>.IndexKeys
+            .Ascending(x => x.MessageTypeName)
+            .Ascending(x => x.PublisherTypeName);
+
+        var indexModel =
+            new CreateIndexModel<MessagePublisherRecord<TMessageId>>(keyIndex, new CreateIndexOptions { Unique = true, Background = true });
+
+        await PublisherCollection.Indexes.CreateOneAsync(indexModel, new CreateOneIndexOptions(), cancellationToken);
+    }
+
+    #endregion
 }

--- a/src/SaanSoft.Cqrs.Store.MongoDB/CommandStore.cs
+++ b/src/SaanSoft.Cqrs.Store.MongoDB/CommandStore.cs
@@ -6,12 +6,15 @@ namespace SaanSoft.Cqrs.Store.MongoDB;
 public class CommandStore(IMongoDatabase database)
     : CommandStore<Guid>(database)
 {
+    protected override Guid NewMessageId() => Guid.NewGuid();
 }
 
 public abstract class CommandStore<TMessageId>(IMongoDatabase database) :
     BaseMessageStore<TMessageId, ICommand<TMessageId>>(database),
-    ICommandStore<TMessageId>
+    ICommandStore<TMessageId>,
+    ICommandPublisherStore
     where TMessageId : struct
 {
     public override string MessageCollectionName => "Commands";
+    public override string PublisherCollectionName => "CommandPublishers";
 }

--- a/src/SaanSoft.Cqrs.Store.MongoDB/EventStore.cs
+++ b/src/SaanSoft.Cqrs.Store.MongoDB/EventStore.cs
@@ -26,6 +26,7 @@ public class EventStore<TEntityKey>(IMongoDatabase database)
 /// <typeparam name="TEntityKey"></typeparam>
 public abstract class EventStore<TMessageId, TEntityKey>(IMongoDatabase database) :
     BaseMessageStore<TMessageId, IEvent<TMessageId>>(database),
+    IEventPublisherStore,
     IEventStore<TMessageId, TEntityKey>
     where TMessageId : struct
     where TEntityKey : struct

--- a/src/SaanSoft.Cqrs.Store.MongoDB/EventStore.cs
+++ b/src/SaanSoft.Cqrs.Store.MongoDB/EventStore.cs
@@ -12,6 +12,7 @@ public class EventStore<TEntityKey>(IMongoDatabase database)
     : EventStore<Guid, TEntityKey>(database)
     where TEntityKey : struct
 {
+    protected override Guid NewMessageId() => Guid.NewGuid();
 }
 
 /// <summary>
@@ -30,6 +31,7 @@ public abstract class EventStore<TMessageId, TEntityKey>(IMongoDatabase database
     where TEntityKey : struct
 {
     public override string MessageCollectionName => "Events";
+    public override string PublisherCollectionName => "EventPublishers";
 
     protected IMongoCollection<IEvent<TMessageId, TEntityKey>> EventCollection =>
         Database.GetCollection<IEvent<TMessageId, TEntityKey>>(MessageCollectionName);
@@ -44,7 +46,7 @@ public abstract class EventStore<TMessageId, TEntityKey>(IMongoDatabase database
     /// <summary>
     /// Call this on your app startup to ensure that the necessary indexes are created
     /// </summary>
-    public override async Task EnsureIndexes(CancellationToken cancellationToken = default)
+    public override async Task EnsureMessageCollectionIndexes(CancellationToken cancellationToken = default)
     {
         var indexes = EventCollection.Indexes;
 

--- a/src/SaanSoft.Cqrs.Store.MongoDB/Models/MessagePublisherRecord.cs
+++ b/src/SaanSoft.Cqrs.Store.MongoDB/Models/MessagePublisherRecord.cs
@@ -1,0 +1,14 @@
+namespace SaanSoft.Cqrs.Store.MongoDB.Models;
+
+public class MessagePublisherRecord<TId> where TId : struct
+{
+    public required TId Id { get; set; }
+
+    public required string MessageTypeName { get; set; }
+
+    public required string PublisherTypeName { get; set; }
+
+    public required DateTime CreatedOn { get; set; }
+
+    public DateTime LastMessageOn { get; set; }
+}

--- a/src/SaanSoft.Cqrs.Store.MongoDB/QueryStore.cs
+++ b/src/SaanSoft.Cqrs.Store.MongoDB/QueryStore.cs
@@ -10,6 +10,7 @@ public class QueryStore(IMongoDatabase database) : QueryStore<Guid>(database)
 
 public abstract class QueryStore<TMessageId>(IMongoDatabase database) :
     BaseMessageStore<TMessageId, IQuery<TMessageId>>(database),
+    IQueryPublisherStore,
     IQueryStore<TMessageId>
     where TMessageId : struct
 {

--- a/src/SaanSoft.Cqrs.Store.MongoDB/QueryStore.cs
+++ b/src/SaanSoft.Cqrs.Store.MongoDB/QueryStore.cs
@@ -5,6 +5,7 @@ namespace SaanSoft.Cqrs.Store.MongoDB;
 
 public class QueryStore(IMongoDatabase database) : QueryStore<Guid>(database)
 {
+    protected override Guid NewMessageId() => Guid.NewGuid();
 }
 
 public abstract class QueryStore<TMessageId>(IMongoDatabase database) :
@@ -13,4 +14,5 @@ public abstract class QueryStore<TMessageId>(IMongoDatabase database) :
     where TMessageId : struct
 {
     public override string MessageCollectionName => "Queries";
+    public override string PublisherCollectionName => "QueryPublishers";
 }

--- a/src/SaanSoft.Cqrs/Bus/BaseBusOptions.cs
+++ b/src/SaanSoft.Cqrs/Bus/BaseBusOptions.cs
@@ -11,6 +11,6 @@ public abstract class BaseBusOptions
     /// <summary>
     /// The log level for log non-critical messages
     /// </summary>
-    /// <value>@default Information</value>
-    public LogLevel LogLevel { get; set; } = LogLevel.Information;
+    /// <value>@default Debug</value>
+    public LogLevel LogLevel { get; set; } = LogLevel.Debug;
 }

--- a/src/SaanSoft.Cqrs/Bus/Decorator/BaseMessagePublisherDecorator.cs
+++ b/src/SaanSoft.Cqrs/Bus/Decorator/BaseMessagePublisherDecorator.cs
@@ -1,0 +1,27 @@
+using System.Diagnostics;
+using SaanSoft.Cqrs.Store;
+
+namespace SaanSoft.Cqrs.Bus.Decorator;
+
+public abstract class BaseMessagePublisherDecorator(IMessagePublisherStore store)
+{
+    protected async Task StorePublisher<TMessage, TPublisher>(CancellationToken cancellationToken)
+    {
+        var messageType = typeof(TMessage);
+        if (messageType == null) return;
+
+        var callerClassType = new StackTrace().GetFrames()
+            .Where(f => !string.IsNullOrWhiteSpace(f.GetMethod()?.DeclaringType?.Namespace))
+            .Where(f => f.GetMethod()!.DeclaringType.IsClass)
+            .Where(f => f.GetMethod()!.DeclaringType.IsVisible)
+            .Where(f => !f.GetMethod()!.DeclaringType.Namespace.StartsWith("System"))
+            .Where(f => !f.GetMethod()!.DeclaringType.Name.Equals(nameof(BaseMessagePublisherDecorator)))
+            .FirstOrDefault(f => f.GetMethod()!.DeclaringType.GetInterface(typeof(TPublisher).Name) == null)
+            ?.GetMethod()
+            ?.DeclaringType;
+
+        var messageTypeName = messageType.FullName ?? messageType.Name;
+        var publishedByName = callerClassType?.FullName ?? callerClassType?.Name ?? "Unknown";
+        await store.UpsertPublisherAsync(messageTypeName, publishedByName, cancellationToken);
+    }
+}

--- a/src/SaanSoft.Cqrs/Bus/Decorator/StoreCommandPublisherDecorator.cs
+++ b/src/SaanSoft.Cqrs/Bus/Decorator/StoreCommandPublisherDecorator.cs
@@ -1,0 +1,47 @@
+using System.Diagnostics;
+using SaanSoft.Cqrs.Messages;
+using SaanSoft.Cqrs.Store;
+
+namespace SaanSoft.Cqrs.Bus.Decorator;
+
+public class StoreCommandPublisherDecorator(ICommandPublisherStore store, ICommandPublisher<Guid> next)
+    : StoreCommandPublisherDecorator<Guid>(store, next);
+
+public class StoreCommandPublisherDecorator<TMessageId>(
+    ICommandPublisherStore store,
+    ICommandPublisher<TMessageId> next)
+    : ICommandPublisher<TMessageId> where TMessageId : struct
+{
+    public async Task<CommandResponse> ExecuteAsync<TCommand>(TCommand command, CancellationToken cancellationToken = default)
+        where TCommand : ICommand<TMessageId>
+    {
+        await StorePublisher<TCommand>(cancellationToken);
+        return await next.ExecuteAsync(command, cancellationToken);
+    }
+
+    public async Task QueueAsync<TCommand>(TCommand command, CancellationToken cancellationToken = default)
+        where TCommand : ICommand<TMessageId>
+    {
+        await StorePublisher<TCommand>(cancellationToken);
+        await next.QueueAsync(command, cancellationToken);
+    }
+
+    private async Task StorePublisher<TCommand>(CancellationToken cancellationToken)
+    {
+        var commandType = typeof(TCommand);
+        if (commandType == null) return;
+
+        var callerClassType = new StackTrace().GetFrames()
+            .Where(f => !string.IsNullOrWhiteSpace(f.GetMethod()?.DeclaringType?.Namespace))
+            .Where(f => f.GetMethod()!.DeclaringType.IsClass)
+            .Where(f => f.GetMethod()!.DeclaringType.IsVisible)
+            .Where(f => !f.GetMethod()!.DeclaringType.Namespace.StartsWith("System"))
+            .FirstOrDefault(f => f.GetMethod()!.DeclaringType.GetInterface(typeof(ICommandPublisher<TMessageId>).Name) == null)
+            ?.GetMethod()
+            ?.DeclaringType;
+
+        var commandTypeName = commandType.FullName ?? commandType.Name;
+        var publishedByName = callerClassType?.FullName ?? callerClassType?.Name ?? "Unknown";
+        await store.UpsertPublisherAsync(commandTypeName, publishedByName, cancellationToken);
+    }
+}

--- a/src/SaanSoft.Cqrs/Bus/Decorator/StoreCommandPublisherDecorator.cs
+++ b/src/SaanSoft.Cqrs/Bus/Decorator/StoreCommandPublisherDecorator.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using SaanSoft.Cqrs.Messages;
 using SaanSoft.Cqrs.Store;
 
@@ -7,41 +6,21 @@ namespace SaanSoft.Cqrs.Bus.Decorator;
 public class StoreCommandPublisherDecorator(ICommandPublisherStore store, ICommandPublisher<Guid> next)
     : StoreCommandPublisherDecorator<Guid>(store, next);
 
-public class StoreCommandPublisherDecorator<TMessageId>(
-    ICommandPublisherStore store,
-    ICommandPublisher<TMessageId> next)
-    : ICommandPublisher<TMessageId> where TMessageId : struct
+public abstract class StoreCommandPublisherDecorator<TMessageId>(ICommandPublisherStore store, ICommandPublisher<TMessageId> next) :
+      BaseMessagePublisherDecorator(store),
+      ICommandPublisher<TMessageId> where TMessageId : struct
 {
     public async Task<CommandResponse> ExecuteAsync<TCommand>(TCommand command, CancellationToken cancellationToken = default)
         where TCommand : ICommand<TMessageId>
     {
-        await StorePublisher<TCommand>(cancellationToken);
+        await StorePublisher<TCommand, ICommandPublisher<TMessageId>>(cancellationToken);
         return await next.ExecuteAsync(command, cancellationToken);
     }
 
     public async Task QueueAsync<TCommand>(TCommand command, CancellationToken cancellationToken = default)
         where TCommand : ICommand<TMessageId>
     {
-        await StorePublisher<TCommand>(cancellationToken);
+        await StorePublisher<TCommand, ICommandPublisher<TMessageId>>(cancellationToken);
         await next.QueueAsync(command, cancellationToken);
-    }
-
-    private async Task StorePublisher<TCommand>(CancellationToken cancellationToken)
-    {
-        var commandType = typeof(TCommand);
-        if (commandType == null) return;
-
-        var callerClassType = new StackTrace().GetFrames()
-            .Where(f => !string.IsNullOrWhiteSpace(f.GetMethod()?.DeclaringType?.Namespace))
-            .Where(f => f.GetMethod()!.DeclaringType.IsClass)
-            .Where(f => f.GetMethod()!.DeclaringType.IsVisible)
-            .Where(f => !f.GetMethod()!.DeclaringType.Namespace.StartsWith("System"))
-            .FirstOrDefault(f => f.GetMethod()!.DeclaringType.GetInterface(typeof(ICommandPublisher<TMessageId>).Name) == null)
-            ?.GetMethod()
-            ?.DeclaringType;
-
-        var commandTypeName = commandType.FullName ?? commandType.Name;
-        var publishedByName = callerClassType?.FullName ?? callerClassType?.Name ?? "Unknown";
-        await store.UpsertPublisherAsync(commandTypeName, publishedByName, cancellationToken);
     }
 }

--- a/src/SaanSoft.Cqrs/Bus/Decorator/StoreEventPublisherDecorator.cs
+++ b/src/SaanSoft.Cqrs/Bus/Decorator/StoreEventPublisherDecorator.cs
@@ -1,0 +1,24 @@
+using SaanSoft.Cqrs.Messages;
+using SaanSoft.Cqrs.Store;
+
+namespace SaanSoft.Cqrs.Bus.Decorator;
+
+public class StoreEventPublisherDecorator(IEventPublisherStore store, IEventPublisher<Guid> next)
+    : StoreEventPublisherDecorator<Guid>(store, next);
+
+public abstract class StoreEventPublisherDecorator<TMessageId>(IEventPublisherStore store, IEventPublisher<TMessageId> next) :
+    BaseMessagePublisherDecorator(store),
+    IEventPublisher<TMessageId> where TMessageId : struct
+{
+    public async Task QueueAsync<TEvent>(TEvent evt, CancellationToken cancellationToken = default) where TEvent : IEvent<TMessageId>
+    {
+        await StorePublisher<TEvent, IEventPublisher<TMessageId>>(cancellationToken);
+        await next.QueueAsync(evt, cancellationToken);
+    }
+
+    public async Task QueueManyAsync<TEvent>(IEnumerable<TEvent> events, CancellationToken cancellationToken = default) where TEvent : IEvent<TMessageId>
+    {
+        await StorePublisher<TEvent, IEventPublisher<TMessageId>>(cancellationToken);
+        await next.QueueManyAsync(events, cancellationToken);
+    }
+}

--- a/src/SaanSoft.Cqrs/Bus/Decorator/StoreQueryPublisherDecorator.cs
+++ b/src/SaanSoft.Cqrs/Bus/Decorator/StoreQueryPublisherDecorator.cs
@@ -1,0 +1,18 @@
+using SaanSoft.Cqrs.Messages;
+using SaanSoft.Cqrs.Store;
+
+namespace SaanSoft.Cqrs.Bus.Decorator;
+
+public class StoreQueryPublisherDecorator(IQueryPublisherStore store, IQueryPublisher<Guid> next)
+    : StoreQueryPublisherDecorator<Guid>(store, next);
+
+public abstract class StoreQueryPublisherDecorator<TMessageId>(IQueryPublisherStore store, IQueryPublisher<TMessageId> next) :
+    BaseMessagePublisherDecorator(store),
+    IQueryPublisher<TMessageId> where TMessageId : struct
+{
+    public async Task<TResponse> QueryAsync<TQuery, TResponse>(IQuery<TQuery, TResponse> query, CancellationToken cancellationToken = default) where TQuery : IQuery<TQuery, TResponse> where TResponse : IQueryResponse
+    {
+        await StorePublisher<TQuery, IQueryPublisher<TMessageId>>(cancellationToken);
+        return await next.QueryAsync(query, cancellationToken);
+    }
+}

--- a/src/SaanSoft.Cqrs/Bus/ICommandPublisher.cs
+++ b/src/SaanSoft.Cqrs/Bus/ICommandPublisher.cs
@@ -38,5 +38,5 @@ public interface ICommandPublisher<TMessageId> where TMessageId : struct
     /// <param name="cancellationToken"></param>
     /// <typeparam name="TCommand"></typeparam>
     /// <returns></returns>
-    Task QueueAsync<TCommand>(TCommand command, CancellationToken cancellationToken) where TCommand : ICommand<TMessageId>;
+    Task QueueAsync<TCommand>(TCommand command, CancellationToken cancellationToken = default) where TCommand : ICommand<TMessageId>;
 }

--- a/src/SaanSoft.Cqrs/Bus/InMemoryCommandBus.cs
+++ b/src/SaanSoft.Cqrs/Bus/InMemoryCommandBus.cs
@@ -48,11 +48,12 @@ public abstract class InMemoryCommandBus<TMessageId>
 
     public async Task<CommandResponse> RunAsync<TCommand>(TCommand command, CancellationToken cancellationToken = default) where TCommand : ICommand<TMessageId>
     {
-        if (command.IsReplay) return new CommandResponse { IsSuccess = true, ErrorMessage = "Commands do not run in replay mode" };
         var handlers = ServiceProvider.GetServices<ICommandHandler<TCommand>>().ToList();
         switch (handlers.Count)
         {
             case 1:
+                if (command.IsReplay) return new CommandResponse { IsSuccess = true, ErrorMessage = "Commands do not run in replay mode" };
+
                 var handler = handlers.Single();
                 if (Logger.IsEnabled(LogLevel))
                 {

--- a/src/SaanSoft.Cqrs/Messages/IMessage.cs
+++ b/src/SaanSoft.Cqrs/Messages/IMessage.cs
@@ -34,6 +34,10 @@ public interface IMessage
 
     /// <summary>
     /// Whether the message is being replayed or not
+    /// Note:
+    /// - Events should replay
+    /// - Queries should replay
+    /// - Commands should NOT replay
     /// </summary>
     bool IsReplay { get; set; }
 }

--- a/src/SaanSoft.Cqrs/Messages/IMessageResponse.cs
+++ b/src/SaanSoft.Cqrs/Messages/IMessageResponse.cs
@@ -3,12 +3,12 @@ namespace SaanSoft.Cqrs.Messages;
 public interface IMessageResponse
 {
     /// <summary>
-    /// Was the query successful or not
+    /// Was the message successful or not
     /// </summary>
     bool IsSuccess { get; set; }
 
     /// <summary>
-    /// Reason for failure, if applicable
+    /// Reason for failure, if IsSuccess=false
     /// </summary>
     string? ErrorMessage { get; set; }
 }

--- a/src/SaanSoft.Cqrs/Messages/IMessageResponse.cs
+++ b/src/SaanSoft.Cqrs/Messages/IMessageResponse.cs
@@ -8,7 +8,7 @@ public interface IMessageResponse
     bool IsSuccess { get; set; }
 
     /// <summary>
-    /// Reason for failure, if IsSuccess=false
+    /// Reason for failure, if applicable
     /// </summary>
     string? ErrorMessage { get; set; }
 }

--- a/src/SaanSoft.Cqrs/Store/ICommandPublisherStore.cs
+++ b/src/SaanSoft.Cqrs/Store/ICommandPublisherStore.cs
@@ -1,0 +1,5 @@
+namespace SaanSoft.Cqrs.Store;
+
+public interface ICommandPublisherStore : IMessagePublisherStore
+{
+}

--- a/src/SaanSoft.Cqrs/Store/IEventPublisherStore.cs
+++ b/src/SaanSoft.Cqrs/Store/IEventPublisherStore.cs
@@ -1,0 +1,6 @@
+namespace SaanSoft.Cqrs.Store;
+
+public interface IEventPublisherStore : IMessagePublisherStore
+{
+
+}

--- a/src/SaanSoft.Cqrs/Store/IMessagePublisherStore.cs
+++ b/src/SaanSoft.Cqrs/Store/IMessagePublisherStore.cs
@@ -1,0 +1,14 @@
+namespace SaanSoft.Cqrs.Store;
+
+public interface IMessagePublisherStore
+{
+    /// <summary>
+    /// Store the class name of the publishers of messages.
+    /// Used with <see ref="StoreCommandPublisherDecorator"/>
+    /// </summary>
+    /// <param name="messageTypeName">Message - type's full name</param>
+    /// <param name="publisherClassTypeName">Class that published the message - type's full name</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    Task UpsertPublisherAsync(string messageTypeName, string publisherClassTypeName, CancellationToken cancellationToken = default);
+}

--- a/src/SaanSoft.Cqrs/Store/IQueryPublisherStore.cs
+++ b/src/SaanSoft.Cqrs/Store/IQueryPublisherStore.cs
@@ -1,0 +1,5 @@
+namespace SaanSoft.Cqrs.Store;
+
+public interface IQueryPublisherStore : IMessagePublisherStore
+{
+}

--- a/test/SaanSoft.Tests.Cqrs.Store.MongoDB/Root/CommandStoreTests.cs
+++ b/test/SaanSoft.Tests.Cqrs.Store.MongoDB/Root/CommandStoreTests.cs
@@ -43,8 +43,28 @@ public class CommandStoreTests : TestSetup
             .Find(x =>
                 x.MessageTypeName == messageName
                 && x.PublisherTypeName == publisherName
-            ).FirstOrDefaultAsync();
+            ).SingleOrDefaultAsync();
 
         record.Should().NotBeNull();
+    }
+
+    [Theory]
+    [InlineAutoData]
+    public async Task UpsertPublisherAsync_multiple_times_only_creates_one_record(string messageName, string publisherName)
+    {
+        await _commandStore.UpsertPublisherAsync(messageName, publisherName);
+        await _commandStore.UpsertPublisherAsync(messageName, publisherName);
+        await _commandStore.UpsertPublisherAsync(messageName, publisherName);
+
+        // check the collection that the record exists
+        var records = await _publisherCollection
+            .Find(x =>
+                x.MessageTypeName == messageName
+                && x.PublisherTypeName == publisherName
+            )
+            .ToListAsync();
+
+        records.Should().NotBeNull();
+        records.Count.Should().Be(1);
     }
 }

--- a/test/SaanSoft.Tests.Cqrs.Store.MongoDB/Root/CommandStoreTests.cs
+++ b/test/SaanSoft.Tests.Cqrs.Store.MongoDB/Root/CommandStoreTests.cs
@@ -1,17 +1,21 @@
+using AutoFixture.Xunit2;
 using SaanSoft.Cqrs.Messages;
 using SaanSoft.Cqrs.Store.MongoDB;
+using SaanSoft.Cqrs.Store.MongoDB.Models;
 
 namespace SaanSoft.Tests.Cqrs.Store.MongoDB.Root;
 
 public class CommandStoreTests : TestSetup
 {
-    private readonly IMongoCollection<IMessage<Guid>> _collection;
+    private readonly IMongoCollection<IMessage<Guid>> _messageCollection;
+    private readonly IMongoCollection<MessagePublisherRecord<Guid>> _publisherCollection;
     private readonly CommandStore _commandStore;
 
     public CommandStoreTests()
     {
         _commandStore = new CommandStore(Database);
-        _collection = _commandStore.MessageCollection;
+        _messageCollection = _commandStore.MessageCollection;
+        _publisherCollection = _commandStore.PublisherCollection;
     }
 
     [Fact]
@@ -21,10 +25,26 @@ public class CommandStoreTests : TestSetup
         await _commandStore.InsertAsync(message);
 
         // check the collection that the command exists
-        var record = await _collection.Find(x => x.Id == message.Id).FirstOrDefaultAsync();
+        var record = await _messageCollection.Find(x => x.Id == message.Id).FirstOrDefaultAsync();
 
         record.Should().NotBeNull();
         record.Id.Should().Be(message.Id);
         record.TypeFullName.Should().Be(typeof(MyCommand).FullName);
+    }
+
+    [Theory]
+    [InlineAutoData]
+    public async Task UpsertPublisherAsync_can_insert_record(string messageName, string publisherName)
+    {
+        await _commandStore.UpsertPublisherAsync(messageName, publisherName);
+
+        // check the collection that the record exists
+        var record = await _publisherCollection
+            .Find(x =>
+                x.MessageTypeName == messageName
+                && x.PublisherTypeName == publisherName
+            ).FirstOrDefaultAsync();
+
+        record.Should().NotBeNull();
     }
 }

--- a/test/SaanSoft.Tests.Cqrs.Store.MongoDB/Root/EventStoreTests.cs
+++ b/test/SaanSoft.Tests.Cqrs.Store.MongoDB/Root/EventStoreTests.cs
@@ -1,17 +1,21 @@
+using AutoFixture.Xunit2;
 using SaanSoft.Cqrs.Messages;
 using SaanSoft.Cqrs.Store.MongoDB;
+using SaanSoft.Cqrs.Store.MongoDB.Models;
 
 namespace SaanSoft.Tests.Cqrs.Store.MongoDB.Root;
 
 public class EventStoreTests : TestSetup
 {
     private readonly IMongoCollection<Event> _collection;
+    private readonly IMongoCollection<MessagePublisherRecord<Guid>> _publisherCollection;
     private readonly EventStore _eventStore;
 
     public EventStoreTests()
     {
         _eventStore = new EventStore(Database);
         _collection = Database.GetCollection<Event>(_eventStore.MessageCollectionName);
+        _publisherCollection = _eventStore.PublisherCollection;
     }
 
     [Fact]
@@ -56,5 +60,41 @@ public class EventStoreTests : TestSetup
             record.Key.Should().Be(message.Key);
             record.TypeFullName.Should().Be(message.GetType().FullName);
         }
+    }
+
+    [Theory]
+    [InlineAutoData]
+    public async Task UpsertPublisherAsync_can_insert_record(string messageName, string publisherName)
+    {
+        await _eventStore.UpsertPublisherAsync(messageName, publisherName);
+
+        // check the collection that the record exists
+        var record = await _publisherCollection
+            .Find(x =>
+                x.MessageTypeName == messageName
+                && x.PublisherTypeName == publisherName
+            ).SingleOrDefaultAsync();
+
+        record.Should().NotBeNull();
+    }
+
+    [Theory]
+    [InlineAutoData]
+    public async Task UpsertPublisherAsync_multiple_times_only_creates_one_record(string messageName, string publisherName)
+    {
+        await _eventStore.UpsertPublisherAsync(messageName, publisherName);
+        await _eventStore.UpsertPublisherAsync(messageName, publisherName);
+        await _eventStore.UpsertPublisherAsync(messageName, publisherName);
+
+        // check the collection that the record exists
+        var records = await _publisherCollection
+            .Find(x =>
+                x.MessageTypeName == messageName
+                && x.PublisherTypeName == publisherName
+            )
+            .ToListAsync();
+
+        records.Should().NotBeNull();
+        records.Count.Should().Be(1);
     }
 }

--- a/test/SaanSoft.Tests.Cqrs.Store.MongoDB/Root/QueryStoreTests.cs
+++ b/test/SaanSoft.Tests.Cqrs.Store.MongoDB/Root/QueryStoreTests.cs
@@ -1,17 +1,21 @@
+using AutoFixture.Xunit2;
 using SaanSoft.Cqrs.Messages;
 using SaanSoft.Cqrs.Store.MongoDB;
+using SaanSoft.Cqrs.Store.MongoDB.Models;
 
 namespace SaanSoft.Tests.Cqrs.Store.MongoDB.Root;
 
 public class QueryStoreTests : TestSetup
 {
     private readonly IMongoCollection<IMessage<Guid>> _collection;
+    private readonly IMongoCollection<MessagePublisherRecord<Guid>> _publisherCollection;
     private readonly QueryStore _queryStore;
 
     public QueryStoreTests()
     {
         _queryStore = new QueryStore(Database);
         _collection = _queryStore.MessageCollection;
+        _publisherCollection = _queryStore.PublisherCollection;
     }
 
     [Fact]
@@ -26,5 +30,41 @@ public class QueryStoreTests : TestSetup
         record.Should().NotBeNull();
         record.Id.Should().Be(message.Id);
         record.TypeFullName.Should().Be(typeof(MyQuery).FullName);
+    }
+
+    [Theory]
+    [InlineAutoData]
+    public async Task UpsertPublisherAsync_can_insert_record(string messageName, string publisherName)
+    {
+        await _queryStore.UpsertPublisherAsync(messageName, publisherName);
+
+        // check the collection that the record exists
+        var record = await _publisherCollection
+            .Find(x =>
+                x.MessageTypeName == messageName
+                && x.PublisherTypeName == publisherName
+            ).SingleOrDefaultAsync();
+
+        record.Should().NotBeNull();
+    }
+
+    [Theory]
+    [InlineAutoData]
+    public async Task UpsertPublisherAsync_multiple_times_only_creates_one_record(string messageName, string publisherName)
+    {
+        await _queryStore.UpsertPublisherAsync(messageName, publisherName);
+        await _queryStore.UpsertPublisherAsync(messageName, publisherName);
+        await _queryStore.UpsertPublisherAsync(messageName, publisherName);
+
+        // check the collection that the record exists
+        var records = await _publisherCollection
+            .Find(x =>
+                x.MessageTypeName == messageName
+                && x.PublisherTypeName == publisherName
+            )
+            .ToListAsync();
+
+        records.Should().NotBeNull();
+        records.Count.Should().Be(1);
     }
 }

--- a/test/SaanSoft.Tests.Cqrs/Bus/Decorator/StoreCommandPublisherDecoratorTests.cs
+++ b/test/SaanSoft.Tests.Cqrs/Bus/Decorator/StoreCommandPublisherDecoratorTests.cs
@@ -33,12 +33,38 @@ public class StoreCommandPublisherDecoratorTests : TestSetup
         A.CallTo(() => store.UpsertPublisherAsync(typeof(MyCommand).FullName!, this.GetType().FullName!, A<CancellationToken>._)).MustHaveHappened();
     }
 
+    [Fact]
+    public async Task QueueAsync_should_store_publisher_details()
+    {
+        var commandPublisher = A.Fake<ICommandPublisher<Guid>>();
+        var store = A.Fake<ICommandPublisherStore>();
+
+        var sut = new StoreCommandPublisherDecorator(store, commandPublisher);
+        await sut.QueueAsync(new MyCommand());
+
+        A.CallTo(() => store.UpsertPublisherAsync(typeof(MyCommand).FullName!, this.GetType().FullName!, A<CancellationToken>._)).MustHaveHappened();
+    }
+
+    [Fact]
+    public async Task QueueAsync_multiple_decorators_should_store_publisher_details()
+    {
+        var commandPublisher = A.Fake<ICommandPublisher<Guid>>();
+        var store = A.Fake<ICommandPublisherStore>();
+
+        var sut = new StoreCommandPublisherDecorator(store, commandPublisher);
+        var wrappedInDecorator = new WrapperCommandPublisher(sut);
+
+        await wrappedInDecorator.QueueAsync(new MyCommand());
+
+        A.CallTo(() => store.UpsertPublisherAsync(typeof(MyCommand).FullName!, this.GetType().FullName!, A<CancellationToken>._)).MustHaveHappened();
+    }
+
     private class WrapperCommandPublisher(ICommandPublisher<Guid> next) : ICommandPublisher<Guid>
     {
         public Task<CommandResponse> ExecuteAsync<TCommand>(TCommand command, CancellationToken cancellationToken = default) where TCommand : ICommand<Guid>
             => next.ExecuteAsync(command, cancellationToken);
 
-        public Task QueueAsync<TCommand>(TCommand command, CancellationToken cancellationToken) where TCommand : ICommand<Guid>
+        public Task QueueAsync<TCommand>(TCommand command, CancellationToken cancellationToken = default) where TCommand : ICommand<Guid>
             => next.QueueAsync(command, cancellationToken);
     }
 }

--- a/test/SaanSoft.Tests.Cqrs/Bus/Decorator/StoreCommandPublisherDecoratorTests.cs
+++ b/test/SaanSoft.Tests.Cqrs/Bus/Decorator/StoreCommandPublisherDecoratorTests.cs
@@ -1,0 +1,44 @@
+using SaanSoft.Cqrs.Bus;
+using SaanSoft.Cqrs.Bus.Decorator;
+using SaanSoft.Cqrs.Messages;
+using SaanSoft.Cqrs.Store;
+
+namespace SaanSoft.Tests.Cqrs.Bus.Decorator;
+
+public class StoreCommandPublisherDecoratorTests : TestSetup
+{
+    [Fact]
+    public async Task ExecuteAsync_should_store_publisher_details()
+    {
+        var commandPublisher = A.Fake<ICommandPublisher<Guid>>();
+        var store = A.Fake<ICommandPublisherStore>();
+
+        var sut = new StoreCommandPublisherDecorator(store, commandPublisher);
+        await sut.ExecuteAsync(new MyCommand());
+
+        A.CallTo(() => store.UpsertPublisherAsync(typeof(MyCommand).FullName!, this.GetType().FullName!, A<CancellationToken>._)).MustHaveHappened();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_multiple_decorators_should_store_publisher_details()
+    {
+        var commandPublisher = A.Fake<ICommandPublisher<Guid>>();
+        var store = A.Fake<ICommandPublisherStore>();
+
+        var sut = new StoreCommandPublisherDecorator(store, commandPublisher);
+        var wrappedInDecorator = new WrapperCommandPublisher(sut);
+
+        await wrappedInDecorator.ExecuteAsync(new MyCommand());
+
+        A.CallTo(() => store.UpsertPublisherAsync(typeof(MyCommand).FullName!, this.GetType().FullName!, A<CancellationToken>._)).MustHaveHappened();
+    }
+
+    private class WrapperCommandPublisher(ICommandPublisher<Guid> next) : ICommandPublisher<Guid>
+    {
+        public Task<CommandResponse> ExecuteAsync<TCommand>(TCommand command, CancellationToken cancellationToken = default) where TCommand : ICommand<Guid>
+            => next.ExecuteAsync(command, cancellationToken);
+
+        public Task QueueAsync<TCommand>(TCommand command, CancellationToken cancellationToken) where TCommand : ICommand<Guid>
+            => next.QueueAsync(command, cancellationToken);
+    }
+}

--- a/test/SaanSoft.Tests.Cqrs/Bus/Decorator/StoreEventPublisherDecoratorTests.cs
+++ b/test/SaanSoft.Tests.Cqrs/Bus/Decorator/StoreEventPublisherDecoratorTests.cs
@@ -1,0 +1,58 @@
+using SaanSoft.Cqrs.Bus;
+using SaanSoft.Cqrs.Bus.Decorator;
+using SaanSoft.Cqrs.Messages;
+using SaanSoft.Cqrs.Store;
+
+namespace SaanSoft.Tests.Cqrs.Bus.Decorator;
+
+public class StoreEventPublisherDecoratorTests : TestSetup
+{
+    [Fact]
+    public async Task QueueAsync_should_store_publisher_details()
+    {
+        var eventPublisher = A.Fake<IEventPublisher<Guid>>();
+        var store = A.Fake<IEventPublisherStore>();
+
+        var sut = new StoreEventPublisherDecorator(store, eventPublisher);
+        await sut.QueueAsync(new MyEvent(Guid.NewGuid()));
+
+        A.CallTo(() => store.UpsertPublisherAsync(typeof(MyEvent).FullName!, this.GetType().FullName!, A<CancellationToken>._)).MustHaveHappened();
+    }
+
+    [Fact]
+    public async Task QueueAsync_multiple_decorators_should_store_publisher_details()
+    {
+        var eventPublisher = A.Fake<IEventPublisher<Guid>>();
+        var store = A.Fake<IEventPublisherStore>();
+
+        var sut = new StoreEventPublisherDecorator(store, eventPublisher);
+        var wrappedInDecorator = new WrapperEventPublisher(sut);
+
+        await wrappedInDecorator.QueueAsync(new MyEvent(Guid.NewGuid()));
+
+        A.CallTo(() => store.UpsertPublisherAsync(typeof(MyEvent).FullName!, this.GetType().FullName!, A<CancellationToken>._)).MustHaveHappened();
+    }
+
+    [Fact]
+    public async Task QueueManyAsync_should_store_publisher_details()
+    {
+        var eventPublisher = A.Fake<IEventPublisher<Guid>>();
+        var store = A.Fake<IEventPublisherStore>();
+        var event1 = new MyEvent(Guid.NewGuid());
+        var event2 = new MyEvent(Guid.NewGuid());
+
+        var sut = new StoreEventPublisherDecorator(store, eventPublisher);
+        await sut.QueueManyAsync([event1, event2]);
+
+        A.CallTo(() => store.UpsertPublisherAsync(typeof(MyEvent).FullName!, this.GetType().FullName!, A<CancellationToken>._)).MustHaveHappened(1, Times.Exactly);
+    }
+
+    private class WrapperEventPublisher(IEventPublisher<Guid> next) : IEventPublisher<Guid>
+    {
+        public Task QueueAsync<TEvent>(TEvent evt, CancellationToken cancellationToken = default) where TEvent : IEvent<Guid>
+            => next.QueueAsync(evt, cancellationToken);
+
+        public Task QueueManyAsync<TEvent>(IEnumerable<TEvent> events, CancellationToken cancellationToken = default) where TEvent : IEvent<Guid>
+            => next.QueueManyAsync(events, cancellationToken);
+    }
+}

--- a/test/SaanSoft.Tests.Cqrs/Bus/Decorator/StoreQueryPublisherDecoratorTests.cs
+++ b/test/SaanSoft.Tests.Cqrs/Bus/Decorator/StoreQueryPublisherDecoratorTests.cs
@@ -1,0 +1,44 @@
+using SaanSoft.Cqrs.Bus;
+using SaanSoft.Cqrs.Bus.Decorator;
+using SaanSoft.Cqrs.Messages;
+using SaanSoft.Cqrs.Store;
+
+namespace SaanSoft.Tests.Cqrs.Bus.Decorator;
+
+public class StoreQueryPublisherDecoratorTests : TestSetup
+{
+    [Fact]
+    public async Task QueryAsync_should_store_publisher_details()
+    {
+        var queryPublisher = A.Fake<IQueryPublisher<Guid>>();
+        var store = A.Fake<IQueryPublisherStore>();
+
+        var sut = new StoreQueryPublisherDecorator(store, queryPublisher);
+        await sut.QueryAsync(new MyQuery());
+
+        A.CallTo(() => store.UpsertPublisherAsync(typeof(MyQuery).FullName!, this.GetType().FullName!, A<CancellationToken>._)).MustHaveHappened();
+    }
+
+    [Fact]
+    public async Task QueryAsync_multiple_decorators_should_store_publisher_details()
+    {
+        var queryPublisher = A.Fake<IQueryPublisher<Guid>>();
+        var store = A.Fake<IQueryPublisherStore>();
+
+        var sut = new StoreQueryPublisherDecorator(store, queryPublisher);
+        var wrappedInDecorator = new WrapperQueryPublisher(sut);
+
+        await wrappedInDecorator.QueryAsync(new MyQuery());
+
+        A.CallTo(() => store.UpsertPublisherAsync(typeof(MyQuery).FullName!, this.GetType().FullName!, A<CancellationToken>._)).MustHaveHappened();
+    }
+
+    private class WrapperQueryPublisher(IQueryPublisher<Guid> next) : IQueryPublisher<Guid>
+    {
+        public Task<TResponse> QueryAsync<TQuery, TResponse>(IQuery<TQuery, TResponse> query,
+            CancellationToken cancellationToken = default) where TQuery :
+            IQuery<TQuery, TResponse>
+            where TResponse : IQueryResponse
+            => next.QueryAsync(query, cancellationToken);
+    }
+}

--- a/test/SaanSoft.Tests.Cqrs/Bus/InMemoryEventBusTests.cs
+++ b/test/SaanSoft.Tests.Cqrs/Bus/InMemoryEventBusTests.cs
@@ -28,7 +28,7 @@ public class InMemoryEventBusTests : TestSetup
     }
 
     [Fact]
-    public async Task ExecuteAsync_single_handler_exists_in_serviceProvider()
+    public async Task QueueAsync_single_handler_exists_in_serviceProvider()
     {
         var eventHandler = A.Fake<IEventHandler<MyEvent>>();
 
@@ -45,7 +45,7 @@ public class InMemoryEventBusTests : TestSetup
     /// and both event handlers should be run
     /// </summary>
     [Fact]
-    public async Task ExecuteAsync_multiple_handlers_exists_in_serviceProvider()
+    public async Task QueueAsync_multiple_handlers_exists_in_serviceProvider()
     {
         var eventHandler = A.Fake<IEventHandler<MyEvent>>();
         var anotherEventHandler = A.Fake<IEventHandler<MyEvent>>();
@@ -64,11 +64,25 @@ public class InMemoryEventBusTests : TestSetup
     /// Unlike commands and queries, having no event handlers is fine, it just does nothing.
     /// </summary>
     [Fact]
-    public async Task ExecuteAsync_no_handler_in_serviceProvider_should_do_nothing()
+    public async Task QueueAsync_no_handler_in_serviceProvider_should_do_nothing()
     {
         var sut = new InMemoryEventBus(GetServiceProvider(), Logger);
         await sut.QueueAsync(new MyEvent(Guid.NewGuid()));
 
         Assert.True(true);
+    }
+
+    [Fact]
+    public async Task QueueManyAsync_executes_multiple_events_of_same_type()
+    {
+        var eventHandler = A.Fake<IEventHandler<MyEvent>>();
+        ServiceCollection.AddScoped<IEventHandler<MyEvent>>(_ => eventHandler);
+        var event1 = new MyEvent(Guid.NewGuid());
+        var event2 = new MyEvent(Guid.NewGuid());
+
+        var sut = new InMemoryEventBus(GetServiceProvider(), Logger, _options);
+        await sut.QueueManyAsync([event1, event2]);
+
+        A.CallTo(() => eventHandler.HandleAsync(A<MyEvent>.That.IsNotNull(), A<CancellationToken>._)).MustHaveHappened(2, Times.Exactly);
     }
 }


### PR DESCRIPTION
### :spiral_notepad: Description

Add a decorators that can put on command/event/query publishers to record which class publishes which messages
Add MongoDB implementations of publisher stores

### :white_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable -->

- [ ] Linked to any related issues in the PR description
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Breaking changes were made
